### PR TITLE
refactored Value to Word

### DIFF
--- a/src/main/java/group1/mips_simulator/components/InstructionExecutions.java
+++ b/src/main/java/group1/mips_simulator/components/InstructionExecutions.java
@@ -1,6 +1,5 @@
 package group1.mips_simulator.components;
 
-import group1.mips_simulator.Utility;
 import group1.mips_simulator.components.cpuParts.ConditionCode;
 import group1.mips_simulator.components.cpuParts.Register;
 import group1.mips_simulator.components.instructionParts.Field;
@@ -189,7 +188,7 @@ public class InstructionExecutions {
         // R3 <− PC+1;
         Register r = computer.cpu.regfile.getGPR(3);
         short pcPlus1 = (short) (computer.cpu.regfile.getPC().read() + 1);
-        r.write(new Value(pcPlus1));
+        r.write(new Word(pcPlus1));
 
         // PC <− EA
         short ea = computer.calculateEA(i);
@@ -215,7 +214,7 @@ public class InstructionExecutions {
 
         // R0 <− Immed
         Register r0 = computer.cpu.regfile.getGPR(0);
-        r0.write(new Value(immed.value));
+        r0.write(new Word(immed.value));
         computer.cpu.regfile.getGPR(0).write(r0.read());
 
         // PC <- c(R3)

--- a/src/main/java/group1/mips_simulator/components/Word.java
+++ b/src/main/java/group1/mips_simulator/components/Word.java
@@ -1,25 +1,24 @@
 package group1.mips_simulator.components;
 
 import group1.mips_simulator.Utility;
-import group1.mips_simulator.components.Config;
 
-public class Value {
+public class Word {
 
     protected short value_;
     protected short size = Config.WORD_SIZE; // 16 by default
 
 
     //region Constructors
-    public Value(short value) {
+    public Word(short value) {
         value_ = value;
     }
 
-    public Value(int value) {
+    public Word(int value) {
         this((short) value);
     }
 
-    public Value clone() {
-        return new Value(this.value_);
+    public Word clone() {
+        return new Word(this.value_);
     }
 
     //endregion
@@ -36,7 +35,7 @@ public class Value {
         this.value_ = value_;
     }
 
-    public void set(Value value_) { this.set(value_.get()); }
+    public void set(Word value_) { this.set(value_.get()); }
 
 
     public void set(int value) {
@@ -91,7 +90,7 @@ public class Value {
             return false;
         }
 
-        Value value = (Value) o;
+        Word value = (Word) o;
         return value_ == value.value_;
     }
     //endregion

--- a/src/main/java/group1/mips_simulator/components/cpuParts/Register.java
+++ b/src/main/java/group1/mips_simulator/components/cpuParts/Register.java
@@ -1,7 +1,7 @@
 package group1.mips_simulator.components.cpuParts;
 
 import group1.mips_simulator.components.Config;
-import group1.mips_simulator.components.Value;
+import group1.mips_simulator.components.Word;
 
 /**
  * A Register is a space that holds a value, and makes it available for
@@ -12,7 +12,7 @@ import group1.mips_simulator.components.Value;
 public class Register {
 
     //getter methods
-    protected Value value = new Value(0);
+    protected Word value = new Word(0);
     protected short bitWidth = Config.WORD_SIZE;
 
     public Register() {
@@ -20,14 +20,14 @@ public class Register {
     }
 
     public Register(short v) {
-        this(new Value(v));
+        this(new Word(v));
     }
 
-    public Register(Value v) {
+    public Register(Word v) {
         this.value = v.clone();
     }
 
-    public Value get() { // previously get()
+    public Word get() { // previously get()
 
         // get the Value in the register
         return this.value;
@@ -39,7 +39,7 @@ public class Register {
     }
 
     // setter methods
-    public void write(Value newValue) {
+    public void write(Word newValue) {
         // set the Value into register
         this.value = newValue.clone();
         this.value.setSize(this.bitWidth);
@@ -47,7 +47,7 @@ public class Register {
 
     public void write(short newValue) {
         // set the Value of the register
-        this.write(new Value(newValue));
+        this.write(new Word(newValue));
     }
 
     public void write(int value_) {

--- a/src/main/java/group1/mips_simulator/components/instructionParts/Instruction.java
+++ b/src/main/java/group1/mips_simulator/components/instructionParts/Instruction.java
@@ -1,6 +1,6 @@
 package group1.mips_simulator.components.instructionParts;
 
-import group1.mips_simulator.components.Value;
+import group1.mips_simulator.components.Word;
 
 import java.util.Arrays;
 import java.util.Objects;
@@ -52,9 +52,9 @@ public class Instruction {
         return (short) rvalue;
     }
 
-    public Value toValue() {
+    public Word toValue() {
         //generate a Value of itself
-        return new Value(this.toShort());
+        return new Word(this.toShort());
     }
 
     /**

--- a/src/main/java/group1/mips_simulator/components/memParts/Memory.java
+++ b/src/main/java/group1/mips_simulator/components/memParts/Memory.java
@@ -12,7 +12,7 @@ package group1.mips_simulator.components.memParts;
 
 import group1.mips_simulator.components.Config;
 import group1.mips_simulator.components.ROM;
-import group1.mips_simulator.components.Value;
+import group1.mips_simulator.components.Word;
 
 /**
  * A Memory class represents the entire memory lookup for our computer simulator.
@@ -36,7 +36,7 @@ public class Memory extends Storage {
     // GETTERS
     /* get() will get the Value from memory */
 
-    public Value get(short address) {
+    public Word get(short address) {
         // get the Value from memory address as a short
         return this.data[address];
     }
@@ -45,7 +45,7 @@ public class Memory extends Storage {
         this.data[address].set(valueToWrite);
     }
 
-    public Value get(int address) {
+    public Word get(int address) {
         // get the Value from memory address as an int
         return get((short) address);
     }
@@ -53,7 +53,7 @@ public class Memory extends Storage {
 
     /* read() will read the short data from memory */
 
-    public short read(Value address) {
+    public short read(Word address) {
         // read the data from address in a Value
         return get(address.get()).get();
     }
@@ -70,7 +70,7 @@ public class Memory extends Storage {
 
 
     // SETTERS
-    public void write(Value address, Value valueToWrite) {
+    public void write(Word address, Word valueToWrite) {
         // write value to address at value
         this.data[address.get()].set(valueToWrite);
     }

--- a/src/main/java/group1/mips_simulator/components/memParts/Storage.java
+++ b/src/main/java/group1/mips_simulator/components/memParts/Storage.java
@@ -1,15 +1,15 @@
 package group1.mips_simulator.components.memParts;
 
-import group1.mips_simulator.components.Value;
+import group1.mips_simulator.components.Word;
 
 public class Storage {
-    public Value[] data;
+    public Word[] data;
 
     public Storage(int size) {
         // Creates an array of values, the data held in storage
-        data = new Value[size];
+        data = new Word[size];
         for(int i = 0; i < data.length; i++){
-            data[i] = new Value(0);
+            data[i] = new Word(0);
         }
     }
 }

--- a/src/test/java/group1/mips_simulator/components/InstructionExecutionsTest.java
+++ b/src/test/java/group1/mips_simulator/components/InstructionExecutionsTest.java
@@ -110,7 +110,7 @@ class InstructionExecutionsTest {
         );
 
         // This value will be written into memory
-        computer.cpu.regfile.getGPR(0).write(new Value(100));
+        computer.cpu.regfile.getGPR(0).write(new Word(100));
 
         // Run code under test to demonstrate change
         assertEquals(0, computer.memory.read((short) 20));


### PR DESCRIPTION
did not adjust variable names from 'value' to 'word' just the datatype because we are still writing the values in, the values are just in the form of words